### PR TITLE
feat: clone icn homepage experience

### DIFF
--- a/src/assets/images/home/brand-aurora.svg
+++ b/src/assets/images/home/brand-aurora.svg
@@ -1,0 +1,4 @@
+<svg width="160" height="60" viewBox="0 0 160 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="160" height="60" rx="12" fill="#0F172A"/>
+  <text x="80" y="38" fill="white" font-family="'Helvetica Neue', sans-serif" font-size="28" font-weight="700" text-anchor="middle">Aurora</text>
+</svg>

--- a/src/assets/images/home/brand-nova.svg
+++ b/src/assets/images/home/brand-nova.svg
@@ -1,0 +1,4 @@
+<svg width="160" height="60" viewBox="0 0 160 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="160" height="60" rx="12" fill="#1E293B"/>
+  <text x="80" y="38" fill="#38BDF8" font-family="'Helvetica Neue', sans-serif" font-size="28" font-weight="700" text-anchor="middle">Nova</text>
+</svg>

--- a/src/assets/images/home/brand-orion.svg
+++ b/src/assets/images/home/brand-orion.svg
@@ -1,0 +1,4 @@
+<svg width="160" height="60" viewBox="0 0 160 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="160" height="60" rx="12" fill="#111827"/>
+  <text x="80" y="38" fill="#A855F7" font-family="'Helvetica Neue', sans-serif" font-size="26" font-weight="700" text-anchor="middle">Orion</text>
+</svg>

--- a/src/assets/images/home/brand-polaris.svg
+++ b/src/assets/images/home/brand-polaris.svg
@@ -1,0 +1,4 @@
+<svg width="160" height="60" viewBox="0 0 160 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="160" height="60" rx="12" fill="#0F172A"/>
+  <text x="80" y="38" fill="#34D399" font-family="'Helvetica Neue', sans-serif" font-size="26" font-weight="700" text-anchor="middle">Polaris</text>
+</svg>

--- a/src/assets/images/home/brand-zenith.svg
+++ b/src/assets/images/home/brand-zenith.svg
@@ -1,0 +1,4 @@
+<svg width="160" height="60" viewBox="0 0 160 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="160" height="60" rx="12" fill="#111827"/>
+  <text x="80" y="38" fill="#FACC15" font-family="'Helvetica Neue', sans-serif" font-size="26" font-weight="700" text-anchor="middle">Zenith</text>
+</svg>

--- a/src/assets/images/home/category-audio.svg
+++ b/src/assets/images/home/category-audio.svg
@@ -1,0 +1,12 @@
+<svg width="130" height="120" viewBox="0 0 130 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="22" y="30" width="30" height="60" rx="10" fill="url(#grad)"/>
+  <rect x="78" y="30" width="30" height="60" rx="10" fill="url(#grad)"/>
+  <circle cx="37" cy="60" r="12" fill="#F9FAFB"/>
+  <circle cx="93" cy="60" r="12" fill="#F9FAFB"/>
+  <defs>
+    <linearGradient id="grad" x1="22" y1="30" x2="118" y2="90" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F97316"/>
+      <stop offset="1" stop-color="#EC4899"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/assets/images/home/category-gaming.svg
+++ b/src/assets/images/home/category-gaming.svg
@@ -1,0 +1,19 @@
+<svg width="140" height="120" viewBox="0 0 140 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="18" y="44" width="104" height="40" rx="18" fill="url(#grad)"/>
+  <circle cx="44" cy="64" r="10" fill="#F9FAFB"/>
+  <rect x="40" y="60" width="8" height="8" rx="2" fill="url(#grad2)"/>
+  <rect x="40" y="60" width="8" height="2" fill="#0F172A"/>
+  <rect x="43" y="57" width="2" height="14" fill="#0F172A"/>
+  <circle cx="96" cy="64" r="10" fill="#F9FAFB"/>
+  <circle cx="96" cy="64" r="4" fill="#0F172A"/>
+  <defs>
+    <linearGradient id="grad" x1="18" y1="44" x2="122" y2="84" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#34D399"/>
+      <stop offset="1" stop-color="#14B8A6"/>
+    </linearGradient>
+    <linearGradient id="grad2" x1="40" y1="60" x2="48" y2="68" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F8FAFC"/>
+      <stop offset="1" stop-color="#E2E8F0"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/assets/images/home/category-laptop.svg
+++ b/src/assets/images/home/category-laptop.svg
@@ -1,0 +1,11 @@
+<svg width="140" height="120" viewBox="0 0 140 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="26" y="18" width="88" height="56" rx="8" fill="url(#grad)"/>
+  <rect x="32" y="26" width="76" height="40" rx="4" fill="#F9FAFB"/>
+  <rect x="18" y="80" width="104" height="16" rx="8" fill="#CBD5F5"/>
+  <defs>
+    <linearGradient id="grad" x1="26" y1="18" x2="114" y2="74" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#A855F7"/>
+      <stop offset="1" stop-color="#6366F1"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/assets/images/home/category-smartphone.svg
+++ b/src/assets/images/home/category-smartphone.svg
@@ -1,0 +1,11 @@
+<svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="38" y="16" width="44" height="88" rx="10" fill="url(#grad)"/>
+  <rect x="44" y="24" width="32" height="64" rx="6" fill="#F9FAFB"/>
+  <rect x="57" y="96" width="8" height="4" rx="2" fill="#F9FAFB"/>
+  <defs>
+    <linearGradient id="grad" x1="38" y1="16" x2="88" y2="104" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#38BDF8"/>
+      <stop offset="1" stop-color="#2563EB"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/assets/images/home/product-camera.svg
+++ b/src/assets/images/home/product-camera.svg
@@ -1,0 +1,13 @@
+<svg width="220" height="220" viewBox="0 0 220 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="46" y="86" width="128" height="84" rx="20" fill="url(#grad)"/>
+  <rect x="82" y="62" width="56" height="32" rx="8" fill="url(#grad)"/>
+  <circle cx="110" cy="128" r="34" fill="#F9FAFB"/>
+  <circle cx="110" cy="128" r="18" fill="#CBD5F5"/>
+  <rect x="140" y="94" width="26" height="14" rx="7" fill="#F9FAFB"/>
+  <defs>
+    <linearGradient id="grad" x1="46" y1="62" x2="174" y2="170" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F59E0B"/>
+      <stop offset="1" stop-color="#F97316"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/assets/images/home/product-console.svg
+++ b/src/assets/images/home/product-console.svg
@@ -1,0 +1,15 @@
+<svg width="220" height="220" viewBox="0 0 220 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="62" y="74" width="96" height="84" rx="18" fill="url(#grad)"/>
+  <rect x="78" y="62" width="64" height="24" rx="12" fill="url(#grad)"/>
+  <circle cx="94" cy="116" r="10" fill="#F9FAFB"/>
+  <circle cx="126" cy="116" r="10" fill="#F9FAFB"/>
+  <circle cx="94" cy="116" r="4" fill="#1F2937"/>
+  <rect x="120" y="110" width="12" height="12" rx="6" fill="#1F2937"/>
+  <rect x="88" y="110" width="12" height="12" rx="6" fill="#1F2937"/>
+  <defs>
+    <linearGradient id="grad" x1="62" y1="62" x2="158" y2="158" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#22D3EE"/>
+      <stop offset="1" stop-color="#0EA5E9"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/assets/images/home/product-headphones.svg
+++ b/src/assets/images/home/product-headphones.svg
@@ -1,0 +1,13 @@
+<svg width="220" height="220" viewBox="0 0 220 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M60 120C60 84.3016 88.3016 56 124 56C159.698 56 188 84.3016 188 120" stroke="url(#grad)" stroke-width="22" stroke-linecap="round"/>
+  <rect x="40" y="118" width="30" height="70" rx="15" fill="url(#grad)"/>
+  <rect x="160" y="118" width="30" height="70" rx="15" fill="url(#grad)"/>
+  <rect x="50" y="132" width="12" height="28" rx="6" fill="#F9FAFB"/>
+  <rect x="178" y="132" width="12" height="28" rx="6" fill="#F9FAFB"/>
+  <defs>
+    <linearGradient id="grad" x1="40" y1="56" x2="190" y2="188" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#EC4899"/>
+      <stop offset="1" stop-color="#F97316"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/assets/images/home/product-laptop.svg
+++ b/src/assets/images/home/product-laptop.svg
@@ -1,0 +1,11 @@
+<svg width="220" height="220" viewBox="0 0 220 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="50" y="50" width="120" height="80" rx="12" fill="url(#grad)"/>
+  <rect x="64" y="64" width="92" height="52" rx="8" fill="#F9FAFB"/>
+  <rect x="34" y="138" width="152" height="22" rx="11" fill="#E0E7FF"/>
+  <defs>
+    <linearGradient id="grad" x1="50" y1="50" x2="170" y2="130" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#7C3AED"/>
+      <stop offset="1" stop-color="#6366F1"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/assets/images/home/product-phone.svg
+++ b/src/assets/images/home/product-phone.svg
@@ -1,0 +1,12 @@
+<svg width="220" height="220" viewBox="0 0 220 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="70" y="30" width="80" height="160" rx="18" fill="url(#grad)"/>
+  <rect x="82" y="50" width="56" height="112" rx="12" fill="#F9FAFB"/>
+  <rect x="102" y="170" width="16" height="8" rx="4" fill="#F9FAFB"/>
+  <circle cx="110" cy="42" r="6" fill="#F9FAFB"/>
+  <defs>
+    <linearGradient id="grad" x1="70" y1="30" x2="158" y2="190" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0284C7"/>
+      <stop offset="1" stop-color="#0EA5E9"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/assets/images/home/product-watch.svg
+++ b/src/assets/images/home/product-watch.svg
@@ -1,0 +1,14 @@
+<svg width="220" height="220" viewBox="0 0 220 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="94" y="40" width="32" height="32" rx="12" fill="url(#grad)"/>
+  <rect x="78" y="70" width="64" height="96" rx="24" fill="url(#grad)"/>
+  <rect x="90" y="82" width="40" height="72" rx="20" fill="#F9FAFB"/>
+  <circle cx="110" cy="118" r="18" fill="#BFDBFE"/>
+  <circle cx="110" cy="118" r="8" fill="#1D4ED8"/>
+  <rect x="94" y="170" width="32" height="32" rx="12" fill="url(#grad)"/>
+  <defs>
+    <linearGradient id="grad" x1="78" y1="40" x2="142" y2="202" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#6366F1"/>
+      <stop offset="1" stop-color="#22D3EE"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/assets/styles/04-components/icn-home.scss
+++ b/src/assets/styles/04-components/icn-home.scss
@@ -1,0 +1,331 @@
+.icn-home {
+  @apply flex flex-col gap-16 lg:gap-24 pb-20;
+
+  .container {
+    @apply mx-auto px-5 sm:px-6 lg:px-8;
+  }
+}
+
+.icn-hero {
+  background: radial-gradient(120% 120% at 100% 0%, rgba(59, 130, 246, 0.18) 0%, rgba(15, 23, 42, 0.9) 55%, rgba(15, 23, 42, 1) 100%);
+  @apply text-white relative overflow-hidden;
+
+  &:before {
+    content: "";
+    position: absolute;
+    inset: 20% -30% auto;
+    height: 480px;
+    border-radius: 999px;
+    background: linear-gradient(135deg, rgba(14, 165, 233, 0.35), rgba(244, 114, 182, 0.1));
+    filter: blur(80px);
+  }
+
+  &__content {
+    @apply relative z-10 flex flex-col lg:flex-row items-stretch py-16 lg:py-20 gap-12 lg:gap-20;
+  }
+
+  &__copy {
+    @apply max-w-2xl flex flex-col gap-6;
+  }
+
+  &__eyebrow {
+    @apply uppercase tracking-[0.3em] text-xs font-semibold text-sky-200;
+  }
+
+  &__title {
+    @apply text-3xl md:text-5xl font-bold leading-tight;
+  }
+
+  &__subtitle {
+    @apply text-base md:text-lg text-slate-200;
+  }
+
+  &__actions {
+    @apply flex flex-wrap gap-3;
+
+    .btn {
+      @apply w-auto;
+    }
+  }
+
+  &__highlights {
+    @apply grid grid-cols-1 sm:grid-cols-3 gap-4 mt-6;
+
+    .icn-hero__highlight {
+      @apply flex items-center gap-3 bg-white/5 backdrop-blur-md rounded-xl p-4;
+
+      i {
+        @apply text-xl text-sky-300;
+      }
+
+      dd {
+        @apply text-sm md:text-base text-slate-100;
+      }
+    }
+  }
+
+  &__visual {
+    @apply flex flex-1 flex-col sm:flex-row items-stretch gap-6 justify-center;
+  }
+}
+
+.icn-hero-card {
+  @apply relative bg-white/10 border border-white/10 rounded-3xl p-6 flex flex-col items-center text-center shadow-[0_25px_60px_rgba(15,23,42,0.3)] min-w-[220px];
+
+  &__badge {
+    @apply text-xs font-semibold uppercase tracking-wide bg-white/15 text-white px-4 py-1 rounded-full mb-4;
+  }
+
+  img {
+    @apply w-40 h-40 object-contain mb-5;
+  }
+
+  &__meta {
+    @apply space-y-1;
+
+    h3 {
+      @apply text-lg font-semibold text-white;
+    }
+
+    p {
+      @apply text-sm text-slate-200;
+    }
+  }
+}
+
+.icn-service-strip {
+  @apply grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6;
+
+  .icn-service-card {
+    @apply bg-white border border-slate-200 rounded-2xl p-6 flex flex-col gap-4 shadow-[0_15px_30px_rgba(15,23,42,0.08)];
+
+    img {
+      @apply w-24 h-24 object-contain self-start;
+    }
+
+    h3 {
+      @apply text-xl font-semibold text-slate-900;
+    }
+
+    p {
+      @apply text-sm text-slate-500;
+    }
+  }
+}
+
+.icn-section {
+  @apply py-16;
+
+  &--dark {
+    background: linear-gradient(135deg, #0f172a, #1e293b);
+    color: white;
+
+    .icn-section__header h2 {
+      @apply text-white;
+    }
+  }
+
+  &--brands {
+    background: linear-gradient(120deg, rgba(15, 23, 42, 0.05), rgba(14, 165, 233, 0.08));
+  }
+
+  &--split {
+    background: linear-gradient(135deg, rgba(248, 250, 252, 1) 0%, rgba(226, 232, 240, 0.6) 100%);
+  }
+
+  &--testimonials {
+    background: radial-gradient(120% 120% at 0% 0%, rgba(14, 165, 233, 0.1) 0%, rgba(248, 250, 252, 1) 55%);
+  }
+
+  &--cta {
+    background: linear-gradient(135deg, #0f172a, #1e3a8a);
+    color: white;
+  }
+
+  &__header {
+    @apply flex flex-col md:flex-row md:items-end md:justify-between gap-4 mb-10;
+
+    h2 {
+      @apply text-2xl md:text-3xl font-bold text-slate-900;
+    }
+  }
+
+  &__eyebrow {
+    @apply uppercase tracking-[0.3em] text-xs font-semibold text-sky-500;
+  }
+
+  &__cta {
+    @apply flex items-center gap-3;
+  }
+}
+
+.icn-link {
+  @apply inline-flex items-center gap-2 text-sm font-semibold text-sky-600 hover:text-sky-800;
+
+  &:after {
+    content: "→";
+    @apply text-base;
+  }
+}
+
+.icn-carousel {
+  @apply grid gap-6 lg:grid-cols-3;
+
+  .icn-carousel-card {
+    @apply bg-white/10 lg:bg-white lg:text-slate-900 border border-white/10 lg:border-slate-200 rounded-3xl overflow-hidden flex flex-col shadow-[0_20px_40px_rgba(15,23,42,0.18)];
+
+    &__media {
+      @apply bg-slate-900/5 flex items-center justify-center p-8;
+
+      img {
+        @apply w-48 h-48 object-contain;
+      }
+    }
+
+    &__body {
+      @apply p-6 space-y-3;
+
+      h3 {
+        @apply text-xl font-semibold;
+      }
+
+      p {
+        @apply text-sm text-slate-500;
+      }
+
+      .icn-price {
+        @apply text-lg font-semibold text-slate-900;
+      }
+
+      .btn {
+        @apply w-auto;
+      }
+    }
+  }
+}
+
+.btn--ghost {
+  @apply border border-white/40 text-white bg-transparent hover:bg-white/10;
+}
+
+.btn--pill {
+  @apply rounded-full bg-sky-600 text-white px-5 py-2 text-sm font-semibold hover:bg-sky-700;
+}
+
+.icn-grid {
+  @apply grid gap-6 md:grid-cols-2 lg:grid-cols-4;
+
+  .icn-grid-card {
+    @apply relative bg-white border border-slate-200 rounded-3xl p-6 flex flex-col gap-5 shadow-[0_20px_40px_rgba(15,23,42,0.08)];
+
+    &__tag {
+      @apply absolute top-6 left-6 bg-sky-100 text-sky-700 text-xs font-semibold px-3 py-1 rounded-full;
+    }
+
+    img {
+      @apply w-40 h-40 object-contain mx-auto;
+    }
+
+    &__body {
+      @apply space-y-2 text-center;
+
+      h3 {
+        @apply text-lg font-semibold text-slate-900;
+      }
+
+      p {
+        @apply text-sm text-slate-500;
+      }
+    }
+  }
+}
+
+.icn-brands {
+  @apply grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4;
+
+  .icn-brand {
+    @apply bg-white border border-slate-200 rounded-2xl flex items-center justify-center p-4 shadow-[0_10px_30px_rgba(15,23,42,0.08)];
+
+    img {
+      @apply max-h-14 w-auto;
+    }
+  }
+}
+
+.icn-journal {
+  @apply grid gap-6 md:grid-cols-2;
+
+  .icn-journal-card {
+    @apply bg-white border border-slate-200 rounded-3xl p-8 flex flex-col gap-3 shadow-[0_20px_40px_rgba(15,23,42,0.08)];
+
+    &__eyebrow {
+      @apply uppercase tracking-[0.3em] text-xs font-semibold text-sky-500;
+    }
+
+    h3 {
+      @apply text-xl font-semibold text-slate-900;
+    }
+
+    p {
+      @apply text-sm text-slate-500;
+    }
+  }
+}
+
+.icn-testimonials {
+  @apply grid gap-6 md:grid-cols-2;
+
+  .icn-testimonial {
+    @apply bg-white border border-slate-200 rounded-3xl p-8 shadow-[0_20px_40px_rgba(15,23,42,0.08)] text-slate-600 text-base leading-relaxed;
+
+    footer {
+      @apply mt-6 flex flex-col;
+    }
+
+    &__author {
+      @apply text-base font-semibold text-slate-900;
+    }
+
+    &__role {
+      @apply text-sm text-slate-500;
+    }
+  }
+}
+
+.icn-cta {
+  @apply flex flex-col lg:flex-row items-start lg:items-center justify-between gap-8;
+
+  &__copy {
+    @apply max-w-xl space-y-4;
+
+    h2 {
+      @apply text-3xl font-bold;
+    }
+
+    p {
+      @apply text-base text-slate-200;
+    }
+  }
+
+  &__form {
+    @apply grid grid-cols-1 sm:grid-cols-3 gap-4 w-full lg:w-auto;
+
+    label {
+      @apply flex flex-col text-sm font-medium gap-2;
+
+      input {
+        @apply rounded-xl border border-white/30 bg-white/10 text-white placeholder:text-slate-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-sky-300;
+      }
+    }
+
+    .btn {
+      @apply sm:col-span-3 w-full;
+    }
+  }
+}
+
+@media (max-width: 768px) {
+  .icn-hero__visual {
+    @apply flex-row;
+  }
+}

--- a/src/assets/styles/app.scss
+++ b/src/assets/styles/app.scss
@@ -75,6 +75,7 @@
 @import './04-components/user-menu';
 @import './04-components/user-pages';
 @import './04-components/home-blocks';
+@import './04-components/icn-home';
 @import './04-components/slider';
 @import './04-components/product';
 @import './04-components/brands';

--- a/src/views/pages/index.twig
+++ b/src/views/pages/index.twig
@@ -1,14 +1,324 @@
-{#
-| Variable         | Type       | Description                                                         |
-|------------------|------------|---------------------------------------------------------------------|
-| page             | object     |                                                                     |
-| page.title       | string     | *could be html                                                      |
-| page.slug        | string     | ex: "cat.show"                                                      |
-#}
 {% extends "layouts.master" %}
+
 {% block content %}
-    {% component home %}
+    {% set hero_highlights = [
+        {
+            label: 'Same-day delivery in Amman',
+            icon: 'sicon-truck-fast'
+        },
+        {
+            label: '2-year warranty on flagship devices',
+            icon: 'sicon-shield-check'
+        },
+        {
+            label: 'Split your payments with Tamara & Tabby',
+            icon: 'sicon-card-pos'
+        }
+    ] %}
+
+    {% set category_cards = [
+        {
+            title: 'Smartphones',
+            description: 'Flagship and mid-range phones curated for performance.',
+            image: cdn('images/home/category-smartphone.svg')
+        },
+        {
+            title: 'Laptops & Tablets',
+            description: 'Ultra-light designs, pro rigs, and everything in between.',
+            image: cdn('images/home/category-laptop.svg')
+        },
+        {
+            title: 'Audio Essentials',
+            description: 'Immersive headphones, earbuds, and smart speakers.',
+            image: cdn('images/home/category-audio.svg')
+        },
+        {
+            title: 'Gaming Gear',
+            description: 'Powerful consoles and accessories for every level.',
+            image: cdn('images/home/category-gaming.svg')
+        }
+    ] %}
+
+    {% set hero_products = [
+        {
+            name: 'Nebula One Pro',
+            price: 'From 389 JOD',
+            badge: '-24% this week',
+            image: cdn('images/home/product-phone.svg')
+        },
+        {
+            name: 'Lumos Studio 15"',
+            price: 'From 799 JOD',
+            badge: 'Free productivity suite',
+            image: cdn('images/home/product-laptop.svg')
+        }
+    ] %}
+
+    {% set trending_products = [
+        {
+            name: 'Pulse ANC Headphones',
+            price: '159 JOD',
+            description: 'Studio-grade sound with adaptive noise control.',
+            image: cdn('images/home/product-headphones.svg')
+        },
+        {
+            name: 'Orbit 4K Action Cam',
+            price: '229 JOD',
+            description: 'Stabilised footage with cinematic presets.',
+            image: cdn('images/home/product-camera.svg')
+        },
+        {
+            name: 'Atlas Series Smartwatch',
+            price: '179 JOD',
+            description: 'Track wellness metrics with multi-day battery.',
+            image: cdn('images/home/product-watch.svg')
+        }
+    ] %}
+
+    {% set spotlight_grid = [
+        {
+            name: 'Nova Stream Console',
+            price: '349 JOD',
+            tag: 'Gamers\' choice',
+            image: cdn('images/home/product-console.svg')
+        },
+        {
+            name: 'Nebula One Pro',
+            price: '389 JOD',
+            tag: 'Back in stock',
+            image: cdn('images/home/product-phone.svg')
+        },
+        {
+            name: 'Lumos Studio 15"',
+            price: '799 JOD',
+            tag: 'Creators\' pick',
+            image: cdn('images/home/product-laptop.svg')
+        },
+        {
+            name: 'Pulse ANC Headphones',
+            price: '159 JOD',
+            tag: 'Staff favourite',
+            image: cdn('images/home/product-headphones.svg')
+        }
+    ] %}
+
+    {% set brand_logos = [
+        cdn('images/home/brand-aurora.svg'),
+        cdn('images/home/brand-nova.svg'),
+        cdn('images/home/brand-zenith.svg'),
+        cdn('images/home/brand-polaris.svg'),
+        cdn('images/home/brand-orion.svg')
+    ] %}
+
+    {% set journal_cards = [
+        {
+            title: 'Your Ramadan tech checklist',
+            summary: 'Streamline family nights with connected lighting, multi-room audio, and productivity apps.',
+            eyebrow: 'Buying guide'
+        },
+        {
+            title: 'Minimal desk, maximum focus',
+            summary: 'Discover the accessories and smart gadgets we rely on to keep creative momentum.',
+            eyebrow: 'Editorial'
+        }
+    ] %}
+
+    {% set testimonials = [
+        {
+            quote: 'Delivery arrived on the same day and the setup session was incredibly helpful. ICN made upgrading effortless.',
+            author: 'Ranya F.',
+            role: 'Amman'
+        },
+        {
+            quote: 'Loved the curated bundles and the instalment options. Finally a tech destination built around Jordanian shoppers.',
+            author: 'Omar H.',
+            role: 'Zarqa'
+        }
+    ] %}
+
+    <main class="icn-home">
+        <section class="icn-hero">
+            <div class="icn-hero__content container">
+                <div class="icn-hero__copy">
+                    <span class="icn-hero__eyebrow">Jordan exclusive launch</span>
+                    <h1 class="icn-hero__title">Experience the next wave of connected living</h1>
+                    <p class="icn-hero__subtitle">Explore a curated line-up of premium electronics, delivered same-day with concierge-level support across the Kingdom.</p>
+                    <div class="icn-hero__actions">
+                        <a href="{{ link('/') }}" class="btn btn--primary">Shop new arrivals</a>
+                        <a href="{{ link('/') }}" class="btn btn--ghost">Book a consultation</a>
+                    </div>
+                    <dl class="icn-hero__highlights">
+                        {% for highlight in hero_highlights %}
+                            <div class="icn-hero__highlight">
+                                <dt><i class="{{ highlight.icon }}" aria-hidden="true"></i></dt>
+                                <dd>{{ highlight.label }}</dd>
+                            </div>
+                        {% endfor %}
+                    </dl>
+                </div>
+                <div class="icn-hero__visual">
+                    {% for product in hero_products %}
+                        <div class="icn-hero-card">
+                            <span class="icn-hero-card__badge">{{ product.badge }}</span>
+                            <img src="{{ product.image }}" alt="{{ product.name }} illustration">
+                            <div class="icn-hero-card__meta">
+                                <h3>{{ product.name }}</h3>
+                                <p>{{ product.price }}</p>
+                            </div>
+                        </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </section>
+
+        <section class="icn-service-strip container">
+            {% for card in category_cards %}
+                <article class="icn-service-card">
+                    <img src="{{ card.image }}" alt="{{ card.title }} illustration">
+                    <div>
+                        <h3>{{ card.title }}</h3>
+                        <p>{{ card.description }}</p>
+                        <a href="{{ link('/') }}" class="icn-link">Explore {{ card.title|lower }}</a>
+                    </div>
+                </article>
+            {% endfor %}
+        </section>
+
+        <section class="icn-section icn-section--dark">
+            <div class="container">
+                <div class="icn-section__header">
+                    <span class="icn-section__eyebrow">Trending now</span>
+                    <h2>Editors' tech radar</h2>
+                    <a href="{{ link('/') }}" class="icn-link">Shop the curation</a>
+                </div>
+                <div class="icn-carousel">
+                    {% for product in trending_products %}
+                        <article class="icn-carousel-card">
+                            <div class="icn-carousel-card__media">
+                                <img src="{{ product.image }}" alt="{{ product.name }} illustration">
+                            </div>
+                            <div class="icn-carousel-card__body">
+                                <h3>{{ product.name }}</h3>
+                                <p>{{ product.description }}</p>
+                                <span class="icn-price">{{ product.price }}</span>
+                                <button class="btn btn--pill" type="button">Add to cart</button>
+                            </div>
+                        </article>
+                    {% endfor %}
+                </div>
+            </div>
+        </section>
+
+        <section class="icn-section">
+            <div class="container">
+                <div class="icn-section__header">
+                    <span class="icn-section__eyebrow">Spotlight</span>
+                    <h2>Future-ready essentials</h2>
+                    <div class="icn-section__cta">
+                        <a href="{{ link('/') }}" class="icn-link">Browse catalogue</a>
+                    </div>
+                </div>
+                <div class="icn-grid">
+                    {% for product in spotlight_grid %}
+                        <article class="icn-grid-card">
+                            <div class="icn-grid-card__tag">{{ product.tag }}</div>
+                            <img src="{{ product.image }}" alt="{{ product.name }} illustration">
+                            <div class="icn-grid-card__body">
+                                <h3>{{ product.name }}</h3>
+                                <p>{{ product.price }}</p>
+                                <a href="{{ link('/') }}" class="icn-link">View details</a>
+                            </div>
+                        </article>
+                    {% endfor %}
+                </div>
+            </div>
+        </section>
+
+        <section class="icn-section icn-section--brands">
+            <div class="container">
+                <div class="icn-section__header">
+                    <span class="icn-section__eyebrow">Brand partners</span>
+                    <h2>Shop iconic innovators</h2>
+                </div>
+                <div class="icn-brands">
+                    {% for logo in brand_logos %}
+                        <div class="icn-brand">
+                            <img src="{{ logo }}" alt="Partner brand logo">
+                        </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </section>
+
+        <section class="icn-section icn-section--split">
+            <div class="container">
+                <div class="icn-section__header">
+                    <span class="icn-section__eyebrow">The ICN journal</span>
+                    <h2>Insights from our experience team</h2>
+                    <a href="{{ link('/') }}" class="icn-link">View all stories</a>
+                </div>
+                <div class="icn-journal">
+                    {% for article in journal_cards %}
+                        <article class="icn-journal-card">
+                            <span class="icn-journal-card__eyebrow">{{ article.eyebrow }}</span>
+                            <h3>{{ article.title }}</h3>
+                            <p>{{ article.summary }}</p>
+                            <a href="{{ link('/') }}" class="icn-link">Read story</a>
+                        </article>
+                    {% endfor %}
+                </div>
+            </div>
+        </section>
+
+        <section class="icn-section icn-section--testimonials">
+            <div class="container">
+                <div class="icn-section__header">
+                    <span class="icn-section__eyebrow">Voices of the community</span>
+                    <h2>Trusted by modern households across Jordan</h2>
+                </div>
+                <div class="icn-testimonials">
+                    {% for item in testimonials %}
+                        <blockquote class="icn-testimonial">
+                            <p>“{{ item.quote }}”</p>
+                            <footer>
+                                <span class="icn-testimonial__author">{{ item.author }}</span>
+                                <span class="icn-testimonial__role">{{ item.role }}</span>
+                            </footer>
+                        </blockquote>
+                    {% endfor %}
+                </div>
+            </div>
+        </section>
+
+        <section class="icn-section icn-section--cta">
+            <div class="container">
+                <div class="icn-cta">
+                    <div class="icn-cta__copy">
+                        <span class="icn-section__eyebrow">Concierge services</span>
+                        <h2>Need a tailored deployment?</h2>
+                        <p>Our specialists design smart home, gaming, and productivity setups from planning to installation.</p>
+                    </div>
+                    <form class="icn-cta__form">
+                        <label>
+                            <span>Your name</span>
+                            <input type="text" placeholder="Full name">
+                        </label>
+                        <label>
+                            <span>Email address</span>
+                            <input type="email" placeholder="you@example.com">
+                        </label>
+                        <label>
+                            <span>Phone number</span>
+                            <input type="tel" placeholder="07XX XXX XXX">
+                        </label>
+                        <button type="submit" class="btn btn--primary">Request a callback</button>
+                    </form>
+                </div>
+            </div>
+        </section>
+    </main>
 {% endblock %}
+
 {% block scripts %}
     <script defer src="{{ 'home.js' | asset }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- rebuild the homepage template with an ICN-inspired hero, merchandising sections, editorial stories, testimonials, and concierge CTA
- add a dedicated SCSS module that styles the new layout, cards, typography, and button variants
- create reusable SVG illustrations for categories, spotlighted products, and partner brands

## Testing
- pnpm production *(fails: missing @babel/runtime helpers in the existing toolchain)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690f678bde3883229d98eebf0cc6f99f)